### PR TITLE
Add required environment for BNFC in build phase

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,11 +17,15 @@
 					version = "0.0.1";
 					src = ./.;
 
+					# BNFC seems to require LANG and glibcLocales to run
+					LANG = "en_US.UTF-8";
+
 					nativeBuildInputs = with pkgs; [
 						ghc
 						haskellPackages.BNFC
 						haskellPackages.alex
 						haskellPackages.happy
+						glibcLocales # For BNFC
 					];
 
 					installPhase = ''


### PR DESCRIPTION
If LANG and LOCALE_ARCHIVE aren't properly set BNFC will for some reason fail with
> hGetContents: invalid argument (cannot decode byte sequence starting from 194)